### PR TITLE
Merge `GitHubPackages` and `NugetOrg` jobs into `Build` job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,6 +105,22 @@ jobs:
         name: drop
         retention-days: 1
 
+    - name: Publish to GitHub Packages
+      if: ${{ github.actor != 'dependabot[bot]' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags')) }}
+      run: >
+        dotnet nuget push "${{ github.workspace }}/drop/*"
+        --source "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json"
+        --api-key ${{ secrets.GITHUB_TOKEN }}
+        --skip-duplicate
+
+    - name: Publish to NuGet.org
+      if: ${{ github.actor != 'dependabot[bot]' && startsWith(github.ref, 'refs/tags') }}
+      run: >
+        dotnet nuget push "${{ github.workspace }}/drop/*"
+        --source "https://api.nuget.org/v3/index.json"
+        --api-key ${{ secrets.NUGET_API_KEY }}
+        --skip-duplicate
+
   Docker:
     runs-on: ubuntu-latest
     needs: Build
@@ -186,56 +202,3 @@ jobs:
           com.github.image.job.id=${{ github.job }}
           com.github.image.source.sha=${{ github.sha }}
           com.github.image.source.branch=${{ github.ref }}
-
-  GitHubPackages:
-    runs-on: ubuntu-latest
-    name: Publish (GitHub Packages)
-    needs: Build
-    if: ${{ github.actor != 'dependabot[bot]' && ((github.ref == 'refs/heads/main') || startsWith(github.ref, 'refs/tags')) }}
-
-    steps:
-    - uses: actions/download-artifact@v4
-      with:
-        name: drop
-        path: ${{ github.workspace }}/drop
-
-    - name: Setup .NET SDK
-      uses: actions/setup-dotnet@v4
-      with:
-        dotnet-version: '9.x'
-        source-url: https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json
-      env:
-        NUGET_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: Publish to nuget.pkg.github.com
-      run: >
-        dotnet nuget push "${{ github.workspace }}/drop/*"
-        -k ${{ secrets.GITHUB_TOKEN }}
-        --skip-duplicate
-
-  NugetOrg:
-    runs-on: ubuntu-latest
-    name: Publish (Nuget.org)
-    needs: Build
-    if: ${{ github.actor != 'dependabot[bot]' && startsWith(github.ref, 'refs/tags') }}
-
-    steps:
-    - uses: actions/download-artifact@v4
-      with:
-        name: drop
-        path: ${{ github.workspace }}/drop
-
-    - name: Setup .NET SDK
-      uses: actions/setup-dotnet@v4
-      with:
-        dotnet-version: 9.x
-        source-url: https://api.nuget.org/v3/index.json
-      env:
-        NUGET_AUTH_TOKEN: ${{ secrets.NUGET_API_KEY }}
-
-    - name: Publish to NuGet.org
-      if: startsWith(github.ref, 'refs/tags/')
-      run: >
-        dotnet nuget push "${{ github.workspace }}/drop/*"
-        -k ${{ secrets.NUGET_API_KEY }}
-        --skip-duplicate


### PR DESCRIPTION
This should make it easier to publish but also reduces the flow tree.