### PR TITLE
Added native binary builds using AoT

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,9 +126,108 @@ jobs:
         --api-key ${{ secrets.NUGET_API_KEY }}
         --skip-duplicate
 
+  Native:
+    strategy:
+      fail-fast: true
+      matrix:
+        os: [ 'macos', 'ubuntu', 'windows' ]
+        arch: [ 'arm64' , 'x64' ]
+        include:
+        # list of RIDs (Runtime Identifiers) can be found at:
+        # https://github.com/dotnet/runtime/blob/main/src/libraries/Microsoft.NETCore.Platforms/src/runtime.json
+        - { os: ubuntu, rid-prefix: 'linux' }
+        - { os: windows, rid-prefix: 'win' }
+        - { os: macos, rid-prefix: 'osx' }
+        # macos-latest uses macos-12 which fails to build the app (macos-13 works)
+        - { os: macos, runs-on: 'macos-13' } # macos-latest
+        - { os: windows, archive-type: 'zip' } # windows creates zip files, others default to 'tar'
+
+    runs-on: ${{ matrix.runs-on || format('{0}-{1}', matrix.os, 'latest') }}
+    needs: Version
+    name: Build Native
+
+    env:
+      DOTNET_RID: ${{ format('{0}-{1}', matrix.rid-prefix, matrix.arch) }}
+      ARCHIVE_EXT: ${{ matrix.archive-type || 'tar.gz' }}
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Setup .NET SDK
+      uses: actions/setup-dotnet@v4
+
+    # NativeAOT does not support full cross-compilation out of the box.
+    # When targeting linux-arm64 from a linux-amd64 GitHub Actions runner:
+    # - The compiler generates ARM64 native object files
+    # - But the host's default linker (ld.bfd or lld) cannot link ARM64 binaries
+    # - We explicitly install and use aarch64-linux-gnu-ld, the cross-linker
+    #
+    # For linux-x64, we skip this override and let the SDK pick the default linker (lld)
+    # This setup allows multi-arch AoT builds in one Dockerfile via docker buildx
+    # Some guidance from
+    # - https://github.com/dotnet/dotnet-docker/blob/main/src/sdk/10.0/trixie-slim-aot/amd64/Dockerfile
+    # - https://github.com/dn-vm/dnvm/blob/main/.github/workflows/publish.yml
+    # - https://github.com/dotnet/runtimelab/issues/1785#issuecomment-993179119
+    # - https://learn.microsoft.com/en-us/dotnet/core/deploying/native-aot
+    # - scouring the web!
+    - name: Install arm64 linker and runtime support
+      if: ${{ matrix.os == 'ubuntu' && matrix.arch == 'arm64' }}
+      run: |
+        sudo apt-get update && \
+        sudo apt-get install -y \
+          clang llvm zlib1g-dev \
+          binutils-aarch64-linux-gnu \
+          gcc-aarch64-linux-gnu \
+          libc6-dev-arm64-cross
+
+    - name: Build & Publish
+      run: >
+        dotnet publish
+        --runtime ${{ env.DOTNET_RID }}
+        --configuration Release
+        -p:PackageVersion=${{ needs.Version.outputs.fullSemVer }}
+        -p:VersionPrefix=${{ needs.Version.outputs.fullSemVer }}
+        -p:PublishAot=true
+        ${{ matrix.os == 'ubuntu' && matrix.arch == 'arm64' && '-p:IlcPath=/usr/bin/aarch64-linux-gnu-ld' || '' }}
+        --output ${{ github.workspace }}/drop/${{ env.DOTNET_RID }}
+        AzureDDNS/AzureDDNS.csproj
+
+    - name: Test (Binary) # ensure the CLI can launch (catches global DI issues)
+      # ARM runners are in preview and we cannot use them, so we skip this test
+      # https://github.blog/changelog/2023-10-30-accelerate-your-ci-cd-with-arm-based-hosted-runners-in-github-actions/
+      # TODO: consider using QEMU emulator for ARM?
+      if: ${{ !contains(matrix.arch, 'arm') }}
+      run: ./azddns --version
+      working-directory: ${{ github.workspace }}/drop/${{ env.DOTNET_RID }}
+
+    - name: Upload Artifact (drop)
+      uses: actions/upload-artifact@v4
+      with:
+        path: ${{ github.workspace }}/drop/**
+        name: drop-${{ env.DOTNET_RID }}
+        retention-days: 1
+
+    - name: Create Archive Folder
+      run: mkdir ${{ github.workspace }}/releases
+
+    - name: Create Archive (${{ matrix.archive-type || 'tar.gz' }})
+      uses: thedoctor0/zip-release@master
+      with:
+        type: ${{ matrix.archive-type || 'tar' }}
+        filename: ${{ github.workspace }}/releases/azddns-${{ needs.Version.outputs.fullSemVer }}-${{ env.DOTNET_RID }}.${{ env.ARCHIVE_EXT }}
+        directory: ${{ github.workspace }}/drop/${{ env.DOTNET_RID }}
+
+    - name: Upload Artifact (releases)
+      uses: actions/upload-artifact@v4
+      with:
+        path: ${{ github.workspace }}/releases/**
+        name: releases-${{ env.DOTNET_RID }}
+        retention-days: 1
+
   Docker:
     runs-on: ubuntu-latest
-    needs: Version
+    needs: [Version, Native]
     env:
       DOCKER_TAGS: '' # helps with intellisense
       IMAGE_NAME: 'azddns'
@@ -136,9 +235,6 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v4
-
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
 
     # Generate tags to use in multi-arch build.
     # This is because we cannot build multi-arch images and load them for later pushing.
@@ -177,6 +273,16 @@ jobs:
         FULL_SEMVER: ${{ needs.Version.outputs.fullSemVer }}
         MAJOR: ${{ needs.Version.outputs.major }}
         MINOR: ${{ needs.Version.outputs.minor }}
+
+    - name: Download Artifact (drop)
+      uses: actions/download-artifact@v4
+      with:
+        path: drop
+        pattern: drop-*
+        merge-multiple: true
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
 
     - name: Log into registry
       if: ${{ !startsWith(github.ref, 'refs/pull') }}

--- a/.gitignore
+++ b/.gitignore
@@ -223,6 +223,7 @@ ClientBin/
 *.pfx
 *.publishsettings
 orleans.codegen.cs
+.DS_Store
 
 # Including strong name files can present a security risk
 # (https://github.com/github/gitignore/pull/2483#issue-259490424)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,56 +1,17 @@
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:9.0 AS build
-
-WORKDIR /src
-COPY . .
-
-ARG TARGETPLATFORM
-ARG VERSION=0.1.0-dev
-
-# Use TARGETPLATFORM to determine the correct runtime ID, validate, then map to RuntimeIdentifier (RID)
-RUN echo "TARGETPLATFORM=${TARGETPLATFORM}" && \
-    case "${TARGETPLATFORM}" in \
-        "linux/amd64") export RID=linux-x64 && export LINKER="" ;; \
-        "linux/arm64") export RID=linux-arm64 && export LINKER="/usr/bin/aarch64-linux-gnu-ld" ;; \
-        *) echo "Unsupported TARGETPLATFORM: ${TARGETPLATFORM}" && exit 1 ;; \
-    esac && \
-    echo "Resolved RID=$RID and LINKER=$LINKER" && \
-    echo $RID > /RID.txt && echo $LINKER > /LINKER.txt
-
-# NativeAOT does not support full cross-compilation out of the box.
-# When targeting linux-arm64 from a linux-amd64 GitHub Actions runner:
-# - The compiler generates ARM64 native object files
-# - But the host's default linker (ld.bfd or lld) cannot link ARM64 binaries
-# - We explicitly install and use aarch64-linux-gnu-ld, the cross-linker
-#
-# For linux-x64, we skip this override and let the SDK pick the default linker (lld)
-# This setup allows multi-arch AoT builds in one Dockerfile via docker buildx
-# Some guidance from https://github.com/dotnet/dotnet-docker/blob/main/src/sdk/10.0/trixie-slim-aot/amd64/Dockerfile
-# but the rest came from scouring the web!
-
-# Install only what's required for AoT per Microsoft patterns + cross linker
-RUN apt-get update \
-    &&  apt-get install -y --no-install-recommends \
-            clang llvm zlib1g-dev \
-            binutils-aarch64-linux-gnu \
-            gcc-aarch64-linux-gnu \
-            libc6-dev-arm64-cross \
-    && rm -rf /var/lib/apt/lists/*
-
-# Publish NativeAOT binary with conditional linker
-RUN export RID=$(cat /RID.txt) && \
-    export LINKER=$(cat /LINKER.txt) && \
-    dotnet publish AzureDDNS/AzureDDNS.csproj \
-        --runtime $RID \
-        --configuration Release \
-        -p:VersionPrefix=$VERSION \
-        -p:PackageVersion=$VERSION \
-        -p:PublishAot=true \
-        ${LINKER:+-p:IlcPath=$LINKER} \
-        --output /app/publish
-
-# Minimal Runtime Image
-FROM mcr.microsoft.com/dotnet/runtime-deps:9.0-alpine AS runtime
+FROM mcr.microsoft.com/dotnet/runtime-deps:9.0-alpine
 
 RUN apk add --no-cache gcompat
-COPY --from=build /app/publish/azddns /bin/azddns
+
+ARG TARGETPLATFORM
+COPY drop/ /drop/
+
+RUN case "$TARGETPLATFORM" in \
+        "linux/amd64") cp /drop/linux-x64/azddns /bin/azddns ;; \
+        "linux/arm64") cp /drop/linux-arm64/azddns /bin/azddns ;; \
+        *) echo "Unsupported: $TARGETPLATFORM" && exit 1 ;; \
+    esac
+
+# remove binaries we don't need
+RUN rm -rf /drop
+
 ENTRYPOINT ["/bin/azddns"]

--- a/Dockerfile.AoT
+++ b/Dockerfile.AoT
@@ -1,0 +1,60 @@
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:9.0 AS build
+
+WORKDIR /src
+COPY . .
+
+ARG TARGETPLATFORM
+ARG VERSION=0.1.0-dev
+
+# Use TARGETPLATFORM to determine the correct runtime ID, validate, then map to RuntimeIdentifier (RID)
+RUN echo "TARGETPLATFORM=${TARGETPLATFORM}" && \
+    case "${TARGETPLATFORM}" in \
+        "linux/amd64") export RID=linux-x64 && export LINKER="" ;; \
+        "linux/arm64") export RID=linux-arm64 && export LINKER="/usr/bin/aarch64-linux-gnu-ld" ;; \
+        *) echo "Unsupported TARGETPLATFORM: ${TARGETPLATFORM}" && exit 1 ;; \
+    esac && \
+    echo "Resolved RID=$RID and LINKER=$LINKER" && \
+    echo $RID > /RID.txt && echo $LINKER > /LINKER.txt
+
+# NativeAOT does not support full cross-compilation out of the box.
+# When targeting linux-arm64 from a linux-amd64 GitHub Actions runner:
+# - The compiler generates ARM64 native object files
+# - But the host's default linker (ld.bfd or lld) cannot link ARM64 binaries
+# - We explicitly install and use aarch64-linux-gnu-ld, the cross-linker
+#
+# For linux-x64, we skip this override and let the SDK pick the default linker (lld)
+# This setup allows multi-arch AoT builds in one Dockerfile via docker buildx
+# Some guidance from
+# - https://github.com/dotnet/dotnet-docker/blob/main/src/sdk/10.0/trixie-slim-aot/amd64/Dockerfile
+# - https://github.com/dn-vm/dnvm/blob/main/.github/workflows/publish.yml
+# - https://github.com/dotnet/runtimelab/issues/1785#issuecomment-993179119
+# - https://learn.microsoft.com/en-us/dotnet/core/deploying/native-aot
+# - scouring the web!
+
+# Install only what's required for AoT per Microsoft patterns + cross linker
+RUN apt-get update \
+    &&  apt-get install -y --no-install-recommends \
+            clang llvm zlib1g-dev \
+            binutils-aarch64-linux-gnu \
+            gcc-aarch64-linux-gnu \
+            libc6-dev-arm64-cross \
+    && rm -rf /var/lib/apt/lists/*
+
+# Publish NativeAOT binary with conditional linker
+RUN export RID=$(cat /RID.txt) && \
+    export LINKER=$(cat /LINKER.txt) && \
+    dotnet publish AzureDDNS/AzureDDNS.csproj \
+        --runtime $RID \
+        --configuration Release \
+        -p:VersionPrefix=$VERSION \
+        -p:PackageVersion=$VERSION \
+        -p:PublishAot=true \
+        ${LINKER:+-p:IlcPath=$LINKER} \
+        --output /app/publish
+
+# Minimal Runtime Image
+FROM mcr.microsoft.com/dotnet/runtime-deps:9.0-alpine AS runtime
+
+RUN apk add --no-cache gcompat
+COPY --from=build /app/publish/azddns /bin/azddns
+ENTRYPOINT ["/bin/azddns"]


### PR DESCRIPTION
These native binaries will form the basis for DEB/RPM/APK files and release assets. Docker images will build easier because we avoid emulation quacks.