### PR TITLE
Add native Linux packaging support (DEB, RPM, APK)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,6 +38,9 @@ permissions:
 
 env:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
+  COMMITTER_USERNAME: ${{ github.repository_owner }}
+  COMMITTER_EMAIL: '1645026+mburumaxwell@users.noreply.github.com'
+  PKG_MAINTAINER: '${{ github.repository_owner }} <1645026+mburumaxwell@users.noreply.github.com>'
 
 jobs:
   Build:
@@ -47,6 +50,7 @@ jobs:
       fullSemVer: ${{ steps.gitversion.outputs.fullSemVer }}
       major: ${{ steps.gitversion.outputs.major }}
       minor: ${{ steps.gitversion.outputs.minor }}
+      majorMinorPatch: ${{ steps.gitversion.outputs.majorMinorPatch }}
 
     steps:
       - name: Checkout
@@ -144,8 +148,14 @@ jobs:
     needs: Build
 
     env:
+      FULL_SEM_VER: ${{ needs.Build.outputs.fullSemVer }}
+      MAJOR_MINOR_PATCH: ${{ needs.Build.outputs.majorMinorPatch }}
       DOTNET_RID: ${{ format('{0}-{1}', matrix.rid-prefix, matrix.arch) }}
       ARCHIVE_EXT: ${{ matrix.archive-type || 'tar.gz' }}
+      PKG_NAME: 'azddns'
+      PKG_DESCRIPTION: 'Dynamic DNS (DDNS) tool for Azure DNS.'
+      PKG_HOMEPAGE: 'https://github.com/mburumaxwell/azddns'
+      LINUX_ARCH: ${{ (matrix.arch == 'x64' && 'amd64') || matrix.arch }}
 
     steps:
       - name: Checkout
@@ -159,8 +169,8 @@ jobs:
           dotnet publish
           --runtime ${{ env.DOTNET_RID }}
           --configuration Release
-          -p:PackageVersion=${{ needs.Build.outputs.fullSemVer }}
-          -p:VersionPrefix=${{ needs.Build.outputs.fullSemVer }}
+          -p:PackageVersion=${{ env.FULL_SEM_VER }}
+          -p:VersionPrefix=${{ env.FULL_SEM_VER }}
           -p:PublishAot=true
           ${{ matrix.os == 'ubuntu' && matrix.arch == 'arm64' && '-p:IlcPath=/usr/bin/aarch64-linux-gnu-ld' || '' }}
           --output ${{ github.workspace }}/binaries/${{ env.DOTNET_RID }}
@@ -189,8 +199,48 @@ jobs:
         uses: thedoctor0/zip-release@main
         with:
           type: ${{ matrix.archive-type || 'tar' }}
-          filename: ${{ github.workspace }}/releases/azddns-${{ needs.Build.outputs.fullSemVer }}-${{ env.DOTNET_RID }}.${{ env.ARCHIVE_EXT }}
+          filename: ${{ github.workspace }}/releases/azddns-${{ env.FULL_SEM_VER }}-${{ env.DOTNET_RID }}.${{ env.ARCHIVE_EXT }}
           directory: ${{ github.workspace }}/binaries/${{ env.DOTNET_RID }}
+
+      - name: Build Linux packages
+        if: ${{ runner.os == 'Linux' }}
+        run: |
+          echo "Preparing .pkgroot ..." && \
+          mkdir -p .pkgroot/usr/bin && \
+          cp -p ${{ github.workspace }}/binaries/${{ env.DOTNET_RID }}/* .pkgroot/usr/bin/ && \
+          mkdir -p .pkgroot/etc/systemd/system && \
+          cp -p packaging/azddns.service .pkgroot/etc/systemd/system/azddns.service && \
+          echo "Prepared .pkgroot" && \
+
+          echo "Installing fpm ..." && \
+          sudo gem install --no-document fpm
+          echo "Installed fpm" && \
+
+          set -e
+          COMMON_ARGS=(
+            --input-type dir
+            --name ${{ env.PKG_NAME }}
+            --version ${{ env.FULL_SEM_VER }}
+            --architecture ${{ env.LINUX_ARCH }}
+            --description "${{ env.PKG_DESCRIPTION }}"
+            --license MIT
+            --maintainer "${{ env.PKG_MAINTAINER }}"
+            --url "${{ env.PKG_HOMEPAGE }}"
+            --prefix /
+            .pkgroot/
+          )
+
+          echo "Building DEB package ..." && \
+          fpm --output-type deb --package ${{ github.workspace }}/releases/azddns-${{ env.FULL_SEM_VER }}-${{ env.DOTNET_RID }}.deb "${COMMON_ARGS[@]}" && \
+          echo "Built DEB package" && \
+
+          echo "Building RPM package ..." && \
+          fpm --output-type rpm --package ${{ github.workspace }}/releases/azddns-${{ env.FULL_SEM_VER }}-${{ env.DOTNET_RID }}.rpm "${COMMON_ARGS[@]}" && \
+          echo "Built RPM package" && \
+
+          echo "Building APK package ..." && \
+          fpm --output-type apk --package ${{ github.workspace }}/releases/azddns-${{ env.FULL_SEM_VER }}-${{ env.DOTNET_RID }}.apk "${COMMON_ARGS[@]}" && \
+          echo "Built APK package"
 
       - name: Upload Artifact (releases)
         uses: actions/upload-artifact@v4
@@ -198,6 +248,28 @@ jobs:
           path: ${{ github.workspace }}/releases/**
           name: releases-${{ env.DOTNET_RID }}
           retention-days: 1
+
+      - name: Test (DEB)
+        if: ${{ runner.os == 'Linux' }}
+        run: |
+          docker run --rm -v "${{ github.workspace }}/releases:/mnt" ubuntu:24.04 /bin/bash -c "
+            apt-get update && \
+            apt-get install -y ./mnt/azddns-${{ env.FULL_SEM_VER }}-${{ env.DOTNET_RID }}.deb
+          "
+
+      - name: Test (RPM)
+        if: ${{ runner.os == 'Linux' }}
+        run: |
+          docker run --rm -v "${{ github.workspace }}/releases:/mnt" almalinux:9 /bin/bash -c "
+            dnf install -y /mnt/azddns-${{ env.FULL_SEM_VER }}-${{ env.DOTNET_RID }}.rpm
+          "
+
+      - name: Test (APK)
+        if: ${{ runner.os == 'Linux' }}
+        run: |
+          docker run --rm -v "${{ github.workspace }}/releases:/mnt" alpine:latest /bin/sh -c "
+            apk add --no-cache --allow-untrusted /mnt/azddns-${{ env.FULL_SEM_VER }}-${{ env.DOTNET_RID }}.apk
+          "
 
   Docker:
     runs-on: ubuntu-latest
@@ -315,7 +387,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [Build, Binaries]
     env:
-      VERSION: ${{ needs.Build.outputs.fullSemVer }}
+      FULL_SEM_VER: ${{ needs.Build.outputs.fullSemVer }}
     outputs:
       fullSemVer: ${{ needs.Build.outputs.fullSemVer }}
 
@@ -338,20 +410,27 @@ jobs:
             const crypto = require('crypto');
             const path = require('path');
 
-            const version = '${{ env.VERSION }}';
+            const version = '${{ env.FULL_SEM_VER }}';
             const dir = '${{ github.workspace }}/releases';
             const outputFile = '${{ github.workspace }}/releases/checksum.txt';
 
             const files = {
-              RELEASE_SHA256_MACOS_ARM64: `azddns-${version}-osx-arm64.tar.gz`,
-              RELEASE_SHA256_MACOS_X64: `azddns-${version}-osx-x64.tar.gz`,
+              RELEASE_SHA256_MACOS_ARM64:     `azddns-${version}-osx-arm64.tar.gz`,
+              RELEASE_SHA256_MACOS_X64:       `azddns-${version}-osx-x64.tar.gz`,
 
-              RELEASE_SHA256_LINUX_ARM64: `azddns-${version}-linux-arm64.tar.gz`,
-              RELEASE_SHA256_LINUX_X64: `azddns-${version}-linux-x64.tar.gz`,
+              RELEASE_SHA256_LINUX_ARM64:     `azddns-${version}-linux-arm64.tar.gz`,
+              RELEASE_SHA256_LINUX_X64:       `azddns-${version}-linux-x64.tar.gz`,
 
-              RELEASE_SHA256_WINDOWS_ARM64: `azddns-${version}-win-arm64.zip`,
-              RELEASE_SHA256_WINDOWS_X86: `azddns-${version}-win-x86.zip`,
-              RELEASE_SHA256_WINDOWS_X64: `azddns-${version}-win-x64.zip`,
+              RELEASE_SHA256_LINUX_ARM64_DEB: `azddns-${version}-linux-arm64.deb`,
+              RELEASE_SHA256_LINUX_X64_DEB:   `azddns-${version}-linux-x64.deb`,
+              RELEASE_SHA256_LINUX_ARM64_RPM: `azddns-${version}-linux-arm64.rpm`,
+              RELEASE_SHA256_LINUX_X64_RPM:   `azddns-${version}-linux-x64.rpm`,
+              RELEASE_SHA256_LINUX_ARM64_APK: `azddns-${version}-linux-arm64.apk`,
+              RELEASE_SHA256_LINUX_X64_APK:   `azddns-${version}-linux-x64.apk`,
+
+              RELEASE_SHA256_WINDOWS_ARM64:   `azddns-${version}-win-arm64.zip`,
+              RELEASE_SHA256_WINDOWS_X86:     `azddns-${version}-win-x86.zip`,
+              RELEASE_SHA256_WINDOWS_X64:     `azddns-${version}-win-x64.zip`,
             };
 
             const lines = [];
@@ -392,6 +471,8 @@ jobs:
           log-level: 'debug'
           if-no-files-found: 'error'
           missing-var-log: 'error'
+        env:
+          VERSION: ${{ env.FULL_SEM_VER }}
 
       - name: Upload Artifact (releases)
         uses: actions/upload-artifact@v4
@@ -410,9 +491,7 @@ jobs:
     needs: [Docker, Packaging]
     if: ${{ startsWith(github.ref, 'refs/tags/') }}
     env:
-      COMMITTER_EMAIL: '1645026+mburumaxwell@users.noreply.github.com'
-      COMMITTER_USERNAME: ${{ github.repository_owner }}
-      VERSION: ${{ needs.Packaging.outputs.fullSemVer }}
+      FULL_SEM_VER: ${{ needs.Packaging.outputs.fullSemVer }}
 
     steps:
       - name: Download Artifact (releases)
@@ -439,6 +518,10 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           body: ${{ steps.changelog.outputs.changelog }}
 
+      # TODO: publish DEB to debian repo available
+      # TODO: publish RPM to rpm repo available
+      # TODO: publish APK to apk repo available
+
       - name: Update homebrew tap
         uses: dmnemec/copy_file_to_another_repo_action@main
         with:
@@ -447,7 +530,7 @@ jobs:
           destination_repo: '${{ github.repository_owner }}/homebrew-tap'
           user_email: '${{ env.COMMITTER_EMAIL }}'
           user_name: '${{ env.COMMITTER_USERNAME }}'
-          commit_message: 'Update azddns to ${{ env.VERSION }}'
+          commit_message: 'Update azddns to ${{ env.FULL_SEM_VER }}'
         env:
           API_TOKEN_GITHUB: ${{ secrets.RELEASING_GITHUB_TOKEN }}
 
@@ -458,6 +541,6 @@ jobs:
           destination_repo: '${{ github.repository_owner }}/scoop-tools'
           user_email: '${{ env.COMMITTER_EMAIL }}'
           user_name: '${{ env.COMMITTER_USERNAME }}'
-          commit_message: 'Update azddns to ${{ env.VERSION }}'
+          commit_message: 'Update azddns to ${{ env.FULL_SEM_VER }}'
         env:
           API_TOKEN_GITHUB: ${{ secrets.RELEASING_GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -165,7 +165,8 @@ docker run --rm -it \
 
 If you’re using azddns on a Raspberry Pi, server, or anywhere systemd is available, you can set it up as a service for automatic startup/restarts.
 
-⚠️ Ensure azddns is installed before proceeding.
+> ![NOTE]
+> Ensure azddns is installed before proceeding using any of the methods in this guide.
 
 1. Copy your config file to a system-wide location:
 
@@ -188,6 +189,15 @@ If you’re using azddns on a Raspberry Pi, server, or anywhere systemd is avail
    ```
 
 3. Copy and enable the systemd unit:
+
+   If you have installed `.deb`, `.rpm`, or `.apk`, the systemd unit file is already included.
+
+   ```bash
+   sudo systemctl daemon-reexec
+   sudo systemctl enable --now azddns
+   ```
+
+   If you are using homebrew or have downloaded the binaries, you need to copy the systemd unit file or download it from GitHub.
 
    ```bash
    sudo cp packaging/azddns.service /etc/systemd/system/azddns.service


### PR DESCRIPTION
Adds native Linux packaging in in three formats: `.deb`, `.rpm`, and `.apk`, supporting `amd64` and `arm64` architectures. The packages include the compiled binary as well as a `systemd` service file for optional use. This enables smoother installation for users on Debian, Ubuntu, CentOS, RHEL, and similar distributions without relying on external tools like Homebrew or manual service setup.

Users are still responsible for creating their own config and environment files in `/etc/azddns`, preserving flexibility and security expectations.