### PR TITLE
Fix mistake in option name for config file

### DIFF
--- a/src/AzureDDNS/RunCommand.cs
+++ b/src/AzureDDNS/RunCommand.cs
@@ -10,7 +10,7 @@ internal class RunCommand : Command
     {
         ArgumentNullException.ThrowIfNull(this.host = host, nameof(host));
 
-        Add(configFileOption = new Option<string>(name: "--config-file", aliases: ["-f"])
+        Add(configFileOption = new Option<string>(name: "--config", aliases: ["-f"])
         {
             Description = "Path to the configuration file",
             Required = true,


### PR DESCRIPTION
Examples shows "--config" but the code expected "--config-file" This changes the code to align with the examples/docs.